### PR TITLE
Add in final uncommitted code

### DIFF
--- a/second-opinion.sequencediagram
+++ b/second-opinion.sequencediagram
@@ -1,0 +1,78 @@
+# This file can be used with http://sequencediagram.org/
+# And rendered to an image file
+
+title Authentication Sequence with OpenID Connect and Second Opinion
+
+participant "User's Browser (User-Agent)" as UserAgent
+participant "Website (Relying Party)" as RP
+participant "Second Opinion OIDC Provider (OP)" as OP
+participant "Duo Security" as Duo
+
+
+RP->OP: GET https:\/\/op.example.net/.well-known/openid-configuration
+OP->RP: JSON meta-data document
+
+note left of OP:JSON meta-data document:\n{"token_endpoint": "https:\/\/op.example.net/oauth/token", \n"authorization_endpoint":"https:\/\/op.example.net/authorize?...",\n[...]}
+
+RP->UserAgent: 302 Redirect to https:\/\/op.example.net/authorize?[...]
+
+note left of RP:GET /authorize parameters:\nstate=xxx (CSRF protection)\nnonce=xxx (server-side replay protection)\nscope=openid email profile\nredirect_uri=https:\/\/rp.example.net/callback (OP will redirect here)\nresponse_type=code\nclient_id=xxx (RP identifier)\nlogin_hint=xxx (email address)
+
+
+UserAgent->OP: GET https:\/\/op.example.net/authorize?[...]
+OP->UserAgent: Show login page with Duo IFrame
+UserAgent->Duo: GET https:\/\/api-4b043da5.duosecurity.com/frame/web/v1/auth?[...]
+
+note right of UserAgent:GET /frame/web/v1/auth parameters:\ntx=xxx (HMAC-SHA1 of login_hint and other values)
+
+Duo->UserAgent: Show IFrame
+UserAgent->Duo: POST https:\/\/api-4b043da5.duosecurity.com/frame/prompt?[...]
+
+note right of UserAgent:POST /frame/prompt parameters:\npasscode=xxx (OTP Code)
+
+Duo->UserAgent: Return signed response
+
+note left of Duo:JSON Document:\n{"response": {\n  "cookie": xxx,\n  [...]\n}}
+
+UserAgent->OP: POST https:\/\/op.example.net/authorize?[...]
+
+note right of UserAgent:POST /authorize parameters:\nsig_response=xxx (Signed response from "cookie")
+
+OP->Duo: GET verify_response(sig_response)
+Duo->OP: authenticated_username
+OP->UserAgent: 302 Redirect to https:\/\/rp.example.net/callback?[...] (redirect_uri)
+
+note left of RP:GET /callback parameters:\nstate=xxx\ncode=xxx
+
+UserAgent->RP: GET https:\/\/rp.example.net/callback?[...]
+RP->OP: POST https:\/\/op.example.net/oauth/token
+
+note right of RP:POST /oauth/token parameters:\nclient_id=xxx\nclient_secret=xxx (secret identifying the RP to the OP)\ngrant_type=authorization_code\ncode=xxx\nstate=xxx
+
+
+OP->RP: JSON {"base64(id_token)", "access_token", ...}
+
+note right of RP:JSON Document:\n{\n\n  "id_token": ADNqVMtqKeYp5w==...,\n  "access_token": xxx,\n  "email": "test@rp.example.net,\n  "attribute1": ...,\n  "attribute2": ...,\n   [...]\n}
+
+RP->RP: Verify id_token signature is valid, signed by OP
+
+
+RP->UserAgent: 302 Redirect https:\/\/rp.example.net/
+note over UserAgent: User is authenticated to https:\/\/rp.example.net
+UserAgent->RP: GET https:\/\/rp.example.net/
+RP->UserAgent: rp.example.net's page is displayed
+
+== 15 minutes later... (session require refresh) ==
+
+
+
+UserAgent->RP: GET https:\/\/rp.example.net/
+RP->UserAgent: 302 Redirect to https:\/\/op.example.net/authorize?**prompt=none**[...]
+
+UserAgent->OP: GET https:\/\/op.example.net/authorize?**prompt=none**[...]
+OP->IdP: silently re-authenticate user
+IdP->OP: return new/current user attributes
+OP->UserAgent: 302 Redirect to https:\/\/rp.example.net/callback?[...] (redirect_uri)
+
+note over UserAgent: User session, expiration and profile attributes are refreshed
+RP->UserAgent: rp.example.net's page is displayed

--- a/second_opinion/app.py
+++ b/second_opinion/app.py
@@ -19,6 +19,7 @@ from oic.oic.provider import UserinfoEndpoint
 from oic.utils.webfinger import OIC_ISSUER
 from oic.utils.webfinger import WebFinger
 from oic.utils.http_util import BadRequest
+from oic.utils.sdb import create_session_db
 import credstash
 import duo_web
 import string
@@ -34,14 +35,163 @@ import gnupg
 import hashlib
 import StringIO
 import boto3
+import errno
+import shelve
+import copy
 
-AWS_LAMBDA_TMP_DIR = '/tmp'
-SIGNING_ROOT_AUTHORITY_FINGERPRINTS = [
-    '85914504D0BFA220E93A6D25B40E5BDC92377335']
-SIGNER_MAP_URL = 's3://infosec-internal-data/second-opinion/prod/signer-map.json'
-SIGNER_MAP_SIG_URL = 's3://infosec-internal-data/second-opinion/prod/signer-map.asc'
+AWS_LAMBDA_TMP_DIR = '/tmp/second-opinion'
+SIGNER_MAP_URL = (
+    's3://infosec-internal-data/second-opinion/prod/signer-map.json')
+SIGNER_MAP_SIG_URL = (
+    's3://infosec-internal-data/second-opinion/prod/signer-map.json.sig')
+SIGNING_ROOT_AUTHORITY_FINGERPRINTS = {
+    SIGNER_MAP_URL: ['85914504D0BFA220E93A6D25B40E5BDC92377335']
+}
+SIGNING_ROOT_AUTHORITY_PUBLIC_KEY = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n\nmQINBFkvHrkBEADSO5RfxrvgWZQFwB6eG3iVSL1Zwb6EZoZRq4Yi6q1Kdx40ZnkR\nFViLN95WrJkr673rJGyUF5nEKrEPz992LVr4aCzxHkKiftLQLkhPh8je55c5esr+\nqSUnK3T6W1LhrFpJc2kOLE/XFNM3DcWHsBhj+UtN2fB9WqfwPsqyjP49GnAwcZNI\n48dl28K3CHH+PN/RF7Tx2alECVCCjQcDLADlaHwvcqtPhzg5dTbtpoPUjWrcsi44\nqs5qKwDKw8C98gppdior4zoRashQTtlvDQQ02pDPXT8AWSi5Dlcp2UVCkumgDooz\nEpFViZYujPmow/Gw/xwLQhZpFm7HDiILfiJTGbaskpZ1ULKbuKjtoFWgcXifOapw\nQAQygkMKWtsYKd8oUfuanMmytDgpZhPRQG0yhTRVf8e72Plsg5roxVMfut4NNXQN\n/h4qRTBj/qMq/Ch9eaAmpdP6c5zuSUjADBduHK3uFeuo9qEmEBsehPM/QD9ma/dy\nYv5i8GolkxiKCJcZDlfsp0WTxhPOtci7BpBZAq7xUUXzYpSib1CxLRZuuRwILlG+\n6lvRABCUDSVA7QpH21eP8VNL4Kauaid0aLyUjpbGxFSkQzoyxiTy5K1D2CkRV0/n\nlX+3sxb61KafAfzw+zTtJJfoAX2mqHG3WefvmhRp6fO6OuvSt0opvcW5swARAQAB\ntEpNb3ppbGxhIFNlY29uZCBPcGluaW9uIFJvb3QgQXV0aG9yaXR5IDxpbmZvc2Vj\nK3NlY29uZC1vcGluaW9uQG1vemlsbGEuY29tPokCNwQTAQoAIQUCWS8euQIbAwUL\nCQgHAwUVCgkICwUWAgMBAAIeAQIXgAAKCRC0DlvckjdzNbLmD/wOYh6uicSkKb7e\nxGgIksmfwdNjRFBg/XhUWV5aLJbGuKdJczEDSSP3nG66r8gk2O4O8fzVjqbY54rd\nscMhaKZRA6EKIS6kai9OAB99QmTfTfiMvpTR2iVS/0vHvl9EqzxfWB7UpRrlcGdh\nSwArk/3s038gers0u3DTnuGbR4dksDm37uDwfkC4FzPTJ6er+GgUbLYrW//4f/1p\ncDqcbaNbM1KOnLwSNM92q9MjvfeyjPwYzMGayJzKKtCPHPrjsmGziMrmXAhzpjL5\n5IoPiLyR7tcoHv1wW8EmYTU5o0GkVW5/Tz4taLbMnyJoQaZoRBXjtGbsUUNcVLGF\ngtAbFZwL7SvqXDcURdVyP307OWEVOcOMUueUp0VMq7XotzpQ+Dp9BcyS6aExazLx\nsiWhB+70dkbKv59xHeiRFgOUIZAqkuMjRvObCWKOwJCQIHMUO5j6d7x7HMxPiClE\ngZFUBOvmcj2ozYIK7lYh+374Op5qkxsHeYwzjI15uXWWkuXuwMbf8FYWMNXbwvp9\nliuowfE5oGd7YJhji0574XO2U8vSfnmlUOv3Rg3VOKcXlzMpVL2rFh+WMn/kjppN\neMvwNhPoZOZ5ettApnHmsegil7XWv+ZuDksDGRkwxC8Sb1Ctm1aedsaul7lm6uoB\n8a9hmrTZMJiyhW8Ew1M9jU822uMW87kCDQRZLx65ARAArznUiSaRNEWTeVuxlEH3\noMbPbP6hvFverpd2XoqCtWFZKf8MrHxNBpcZ2o4c3uSgy229aDnWbNscqtMSuC/H\n9MXCCRxGKTno7MTTOIN2/SrUYiuFjKLx91tBRO4rJcB5u4salCCx9vH8RuIyHmE+\ntKoSiqN6wSxyhKyRbkcdOHk5zboovpJ6GjuJlATue+fFKZY5Rlbg2yDqSibovZua\nBTZdVeB6bndiJEfbDzHQ1XcbDLCRseHdRRT/QVOxwreiNF58lO/Y/9Ilr0j/LAEr\nkuGVdTGzxrC0AZ6sRumar3ujL7yVye171tDAmuz0imbigtqfxBmRITLL5utZqmd6\nLxqbn0TxIGKqoqkoYUIu+N0AeeM53i7fUHyVyZcY7C7pWep8KA265DruyCSkspxs\n4k4s/x5+LGORWoJHopCZY+naoXi9lCid7r8cOAVfiod4FREJKYsRHflk1XWO/Owh\nx40HvR4/AdjfDWTPMRdCYlIn/9kOtwelaEreRva75gXIKTE49I7OmgoABSdvLlYD\nOpk7i8LLXPgQFpRR4tkUNfEmEpq8FIr/InyA+Gm2a61/Ue3Kt5yjOfzgAR08Wr+S\njZ1416yzwkKF+Rcs/fwo9qVlyzaEMRFlbK9LalPGcdS1p4eHulc/2Xe5FdcktPDQ\nmmFGVz1vQvGkomga9MaoFcMAEQEAAYkCHwQYAQoACQUCWS8euQIbDAAKCRC0Dlvc\nkjdzNVbZEAChs+VSl1mG8045L6vqSx96DvoxhQxE5HDTqZ3cFgHl9lR/tt4Z0e3G\nLHOypgklJgHNqIlYmksADCl4+LiWjm+Qem/4OPlUi7qeFtD4rvMAiG/fMJgDRBve\nY0CnS42ZlDFC3vXL3AhkIIeqZ5Z/9oiNSgbgpT0whrls3A3Crqt1TUGUhHxuELRB\nXbr0Z7ddlHP+G2tk6qpXrgBZWpBh6isCEuNfmd75QqHpoww3UHydUqHmZj5ridlL\ng0IbBKzAX5HfKovq3pX50mpBPezoRySiKOYTOqvzRh/K1obwb4fEBqEki9fxEGr9\nsUgAD4/BoPXsb8maLRB/Dk9qoO5xex4NxCfHJifL07JlcOUKGczGyUpnW1b3R5eF\n/91RN2ocKV9cBUIwahU86XOZpY/ODlFfWoiOOP9WAewCPCWKeJDmVk4Obp/VHVEZ\nLZpSKPuuOYrr+yazFce+C+iwfZtNbd0U8SME2OEBjtH4DWQQHElx5Xun+j7onmKS\nRKI1DVmJGnXypZWYcPhYhPiws9PYZy9sWuduKDz57AtWH9umcPB0UW8loulJkMDd\nLeW/lT3FjT6mGhknvKlC2to7NrNUxI/b7VkIfz0Lch5UdlDiiue8ZeWFyI8lw5RA\nf3RISnjJzf9gTlbbgRClXU73sAAfnrS8TdcAylnZ0byieERcvQlNHw==\n=gXVD\n-----END PGP PUBLIC KEY BLOCK-----"
+
+try:
+    os.makedirs(AWS_LAMBDA_TMP_DIR, 0700)
+except OSError as e:
+    if e.errno != errno.EEXIST or not os.path.isdir(AWS_LAMBDA_TMP_DIR):
+        raise
 memory = Memory(cachedir=AWS_LAMBDA_TMP_DIR)
-gpg = gnupg.GPG(homedir=AWS_LAMBDA_TMP_DIR)
+gpg = gnupg.GPG(homedir=AWS_LAMBDA_TMP_DIR, verbose=False)
+
+
+def get_url_or_s3_object(url):
+    """Fetch the payload of a url from either the web or s3
+
+    :param str url:
+    :return: tuple of (success, payload)
+    """
+    # TODO : Add argument to pass s3 region optionally so that this s3 fetch
+    #  can skip the redirect from the local region to the region of the bucket
+    if url.startswith('s3://'):
+        client = boto3.client('s3')
+        bucket_name = url[5:].split('/')[0]
+        key_name = '/'.join(url[5:].split('/')[1:])
+        try:
+            response = client.get_object(
+                Bucket=bucket_name,
+                Key=key_name
+            )
+        except Exception as e:
+            app.logger.error(
+                "Unable to fetch %s : %s" % (url, e))
+            return False, ''
+        else:
+            return True, response['Body'].read()
+    else:
+        response = requests.get(url)
+        if not response.ok:
+            app.logger.error(
+                "Unable to fetch %s : %s" % (url, response.reason))
+        return response.ok, response.content
+
+
+@memory.cache
+def fetch_and_verify(page_url, signature_url, signer_map):
+    """Fetch content from page_url and a detached signature from
+    signature_url, gpg verify that the detached signature is valid for
+    the page and that the signer is in the signer_map. Return the page or
+    False.
+
+    :param str page_url: URL of the page to fetch
+    :param str signature_url: URL of the detached signature for page_url
+    :param dict signer_map: Dictionary where each key is a URL and each
+    value is a list of GPG fingerprints that are
+    authorized to sign the page at that URL
+    :return: payload for page_url or the content of return_on_error if
+    there is a problem with fetching or verification
+    """
+    page_success, page = get_url_or_s3_object(page_url)
+    signature_success, signature = get_url_or_s3_object(signature_url)
+    if not (page_success and signature_success):
+        return False
+
+    matching_authorized_signer_lists = [
+        signer_map[url_prefix] for url_prefix
+        in signer_map
+        if page_url.startswith(url_prefix)]
+    if len(matching_authorized_signer_lists) == 0:
+        raise Exception(
+            "No matching allowed signers for %s found in signer map" %
+            page_url)
+    elif len(matching_authorized_signer_lists) > 1:
+        raise Exception(
+            "Multiple matching allowed signer lists found for %s : "
+            "%s" % (page_url, matching_authorized_signer_lists))
+    [authorized_signers] = matching_authorized_signer_lists
+    signature_filename = os.path.join(
+        AWS_LAMBDA_TMP_DIR,
+        hashlib.sha256(page).hexdigest()
+    )
+    with open(signature_filename, 'w') as signature_file:
+        signature_file.write(signature)
+    import subprocess
+    # app.logger.debug("gpg version is %s" %
+    #                  subprocess.check_output(["/usr/bin/gpg2", "--version"]))
+    verification_result = gpg.verify_file(
+        file=StringIO.StringIO(page),
+        sig_file=signature_filename
+    )
+    if not verification_result.valid:
+        app.logger.error(
+            "Unable to verify %s with detached signature %s : %s" % (
+                page_url, signature_url, verification_result.status
+            ))
+        return False
+    if verification_result.fingerprint not in authorized_signers:
+        app.logger.error(
+            "Valid signature by %s of %s is not an authorized signer" % (
+                verification_result.fingerprint, page_url
+            ))
+        return False
+    try:
+        result = json.loads(page)
+    except ValueError:
+        return False
+    else:
+        return result
+
+
+class ShelfWrapper(object):
+    def __init__(self, filename):
+        self.filename = filename
+
+    def keys(self):
+        db = self._reopen_database()
+        return db.keys()
+
+    def __len__(self):
+        db = self._reopen_database()
+        return db.__len__()
+
+    def has_key(self, key):
+        return (key if type(key) == str else key.encode('utf8')) in self
+
+    def __contains__(self, key):
+        db = self._reopen_database()
+        return db.__contains__(key if type(key) == str else key.encode('utf8'))
+
+    def get(self, key, default=None):
+        db = self._reopen_database()
+        return db.get(key if type(key) == str else key.encode('utf8'), default)
+
+    def __getitem__(self, key):
+        db = self._reopen_database()
+        return db.__getitem__(key if type(key) == str else key.encode('utf8'))
+
+    def __setitem__(self, key, value):
+        db = self._reopen_database()
+        db.__setitem__(key if type(key) == str else key.encode('utf8'), value)
+
+    def __delitem__(self, key):
+        db = self._reopen_database()
+        db.__delitem__(key if type(key) == str else key.encode('utf8'))
+
+    def _reopen_database(self):
+        return shelve.open(self.filename, writeback=True)
 
 
 class UserInfoWithGroups(UserInfo):
@@ -63,6 +213,9 @@ class UserInfoWithGroups(UserInfo):
         :return: A dictionary of filtered claims.
         """
 
+        logging.debug(
+            "app.py UserInfoWithGroups.filter: userinfo, user_info_claims = "
+            "%s, %s" % (userinfo, user_info_claims))
         if user_info_claims is None:
             return copy.copy(userinfo)
         else:
@@ -79,12 +232,16 @@ class UserInfoWithGroups(UserInfo):
                         missing.append(key)
                     else:
                         optional.append(key)
+            logging.debug(
+                "app.py UserInfoWithGroups.filter: result = "
+                "%s" % result)
             return result
 
 
 class DuoAuthnMethod(UserAuthnMethod):
-    def __init__(self, app, **kwargs):
-        super(DuoAuthnMethod, self).__init__(None)
+    def __init__(self, srv, app, ttl=5, **kwargs):
+        UserAuthnMethod.__init__(self, srv, ttl)
+        # super(DuoAuthnMethod, self).__init__(None)
         self.app = app
 
     def __call__(self, *args, **kwargs):
@@ -191,6 +348,11 @@ class DuoAuthnMethod(UserAuthnMethod):
             self.app.config['credentials']['second-opinion:duo:akey'],
             request.form['sig_response']
         )
+        self.app.logger.debug(
+            "Result of Duo verify_response of '%s' with ikey %s : %s" %
+            (request.form['sig_response'],
+             self.app.config['credentials']['second-opinion:duo:ikey'],
+             authenticated_username))
 
         # The behaviour seen in other pyoidc UserAuthnMethod classes returns
         #  both the authenticated username and a boolean `completed` value.
@@ -218,6 +380,21 @@ class DuoAuthnMethod(UserAuthnMethod):
             # into calls to response.set_cookie so Flask can set the cookies
             cookie = SimpleCookie(cookie_value)
             for cookie_name in cookie:
+                self.app.logger.debug(
+                    "Setting cookie %s to %s with args %s" % (
+                        cookie_name,
+                        cookie[cookie_name].value,
+                        {k: v for k, v
+                         in cookie[cookie_name].iteritems()
+                         if k in ['key',
+                                  'max_age',
+                                  'expires',
+                                  'path',
+                                  'domain',
+                                  'secure',
+                                  'httponly']
+                         and len(cookie[cookie_name][k]) > 0}
+                    ))
                 response.set_cookie(
                     key=cookie_name,
                     value=cookie[cookie_name].value,
@@ -240,6 +417,9 @@ class DuoAuthnMethod(UserAuthnMethod):
 class PyOIDCOP(object):
     def __init__(self, app=None):
         self.app = app
+        self.sdb = ShelfWrapper('/tmp/session_db')
+        self.provider = None
+        self.authn_broker = AuthnBroker()
         if app is not None:
             self.init_app(app)
 
@@ -268,42 +448,32 @@ class PyOIDCOP(object):
 
         app.teardown_appcontext(self.teardown)  # Flask 0.9 or newer
 
-        self.authn_broker = AuthnBroker()
-        duo_auth_instance = DuoAuthnMethod(self.app)
-        self.authn_broker.add("duo", duo_auth_instance)
+        # TODO : Consider if this flimsy persistence is good enough. If the
+        # lambda host changes between calls this session persistence will fail
 
         # /duo/verify
-        self.app.add_url_rule(
-            rule=self.app.config['OP_DUO_VERIFY_ROUTE'],
-            endpoint='verify',
-            view_func=duo_auth_instance.verify,
-            methods=['POST'])
-
-        client_id = request.args.get('client_id', None)
-        provider = self.get_provider(self.get_userinfo(client_id))
+        def verify():
+            return DuoAuthnMethod(self.provider, self.app).verify()
 
         # /.well-known/jwks.json
-        @self.app.route(self.app.config['OP_JWKS_ROUTE'])
         def jwks():
+            provider = self.get_provider(
+                self.get_userinfo(request.args.get('client_id', None)))
             return jsonify(provider.keyjar.export_jwks(private=False))
 
         # /authorization
-        @self.app.route(
-            "/{}".format(AuthorizationEndpoint.etype),
-            methods=['GET', 'POST'])
         def authorization():
-            return provider.authorization_endpoint(
+            a = self.provider.authorization_endpoint(
                 request=request.values.to_dict(),
                 cookie=SimpleCookie(request.cookies).output(
                     header='', sep='; ')
             )
+            self.app.logger.debug("Result of authorization endpoint : %s" % a)
+            return a
 
         # /token
-        @self.app.route(
-            "/{}".format(TokenEndpoint.etype),
-            methods=['POST'])
         def token():
-            return provider.token_endpoint(
+            return self.provider.token_endpoint(
                 request=request.values.to_dict(),
                 dtype='dict',
                 cookie=SimpleCookie(request.cookies).output(
@@ -311,9 +481,8 @@ class PyOIDCOP(object):
             )
 
         # /userinfo
-        @self.app.route("/{}".format(UserinfoEndpoint.etype))
         def userinfo():
-            return provider.userinfo_endpoint(
+            return self.provider.userinfo_endpoint(
                 request=request.values.to_dict(),
                 cookie=SimpleCookie(request.cookies).output(
                     header='', sep='; '),
@@ -321,51 +490,94 @@ class PyOIDCOP(object):
             )
 
         # /registration
-        @self.app.route("/{}".format(RegistrationEndpoint.etype))
         def registration():
-            return provider.registration_endpoint(
+            return self.provider.registration_endpoint(
                 request=request.values.to_dict(),
                 cookie=SimpleCookie(request.cookies).output(
                     header='', sep='; ')
             )
 
         # /end_session
-        @self.app.route("/{}".format(EndSessionEndpoint.etype))
         def end_session():
-            return provider.endsession_endpoint(
+            return self.provider.endsession_endpoint(
                 request=request.values.to_dict(),
                 cookie=SimpleCookie(request.cookies).output(
                     header='', sep='; ')
             )
 
         # /.well-known/openid-configuration
-        @self.app.route("/.well-known/openid-configuration")
         def providerinfo():
-            return provider.providerinfo_endpoint(
+            return self.provider.providerinfo_endpoint(
                 request=request.values.to_dict(),
                 cookie=SimpleCookie(request.cookies).output(
                     header='', sep='; ')
             )
 
         # /.well-known/webfinger
-        @self.app.route("/.well-known/webfinger")
         def webfinger():
             if request.values["rel"] == OIC_ISSUER:
                 wf = WebFinger()
                 return Response(
                     wf.response(
                         request.values["resource"],
-                        provider.baseurl
+                        self.provider.baseurl
                     )), [("Content-Type", "application/jrd+json")]
             else:
                 return BadRequest("Incorrect webfinger.")
 
-                # /static
-                # Served automatically from the static directory
-                # http://flask.pocoo.org/docs/0.12/quickstart/#static-files
+        # /static
+        # Served automatically from the static directory
+        # http://flask.pocoo.org/docs/0.12/quickstart/#static-files
+
+        # /clear-cache
+        @self.app.route("/clear-cache")
+        def clear_cache():
+            memory.clear()
+            return "Success"
+
+        self.app.add_url_rule(
+            rule=self.app.config['OP_DUO_VERIFY_ROUTE'],
+            endpoint='verify',
+            view_func=self.call_view_func(verify),
+            # TODO : should this instead be make_auth_verify(duo_auth_instance.verify)?
+            methods=['POST'])
+        self.app.add_url_rule(
+            rule=self.app.config['OP_JWKS_ROUTE'],
+            endpoint='jwks',
+            view_func=self.call_view_func(jwks))
+        self.app.add_url_rule(
+            rule="/{}".format(AuthorizationEndpoint.etype),
+            endpoint='authorization',
+            view_func=self.call_view_func(authorization),
+            methods=['GET', 'POST'])
+        self.app.add_url_rule(
+            rule="/{}".format(TokenEndpoint.etype),
+            endpoint='token',
+            view_func=self.call_view_func(token),
+            methods=['POST'])
+        self.app.add_url_rule(
+            rule="/{}".format(UserinfoEndpoint.etype),
+            endpoint='userinfo',
+            view_func=self.call_view_func(userinfo))
+        self.app.add_url_rule(
+            rule="/{}".format(RegistrationEndpoint.etype),
+            endpoint='registration',
+            view_func=self.call_view_func(registration))
+        self.app.add_url_rule(
+            rule="/{}".format(EndSessionEndpoint.etype),
+            endpoint='end_session',
+            view_func=self.call_view_func(end_session))
+        self.app.add_url_rule(
+            rule="/.well-known/openid-configuration",
+            endpoint='providerinfo',
+            view_func=self.call_view_func(providerinfo))
+        self.app.add_url_rule(
+            rule="/.well-known/webfinger",
+            endpoint='webfinger',
+            view_func=self.call_view_func(webfinger))
 
     def load_config(self):
-        """Build the configuration by overlaying DEFAULTS with environment
+        """Build the configuration by overlaying defaults with environment
         variables and with config drawn from the CONFIG_URL page. Add in
         secrets from credstash. Add in authorization data for the users of
         each relying party.
@@ -374,36 +586,48 @@ class PyOIDCOP(object):
         """
 
         # Establish default configuration values
-        DEFAULTS = {
+        defaults = {
             'DEBUG': True,
             'OP_ISSUER': 'https://second-opinion.security.allizom.org',
             'OP_JWKS_ROUTE': '/.well-known/jwks.json',
             'OP_DUO_VERIFY_ROUTE': '/duo/verify',
             'OP_USERINFO': {},
-            'OP_CLIENT_DB': {}
+            'OP_CLIENT_DB': {},
+            'OP_AUTHORIZATION_DATA': {},
+            'SYMKEY': '0123456789012345',
+            'SESSION_KEY': "a"*64,
+            'DEFAULT_TOKEN_SECRET_KEY': 'bbccbbcc'
         }
 
-        app.config.update(DEFAULTS)
+        # TODO : Move these secrets into credstash
+
+        app.config.update(defaults)
 
         # Override the defaults with any environment variables
-        for v in [x for x in os.environ if x in DEFAULTS]:
+        for v in [x for x in os.environ if x in defaults]:
             self.app.config[v] = os.environ.get(v)
 
         # Fetch the signer map
-        self.app.config['SIGNER_MAP'] = self.fetch_and_verify(
+        gpg.import_keys(SIGNING_ROOT_AUTHORITY_PUBLIC_KEY)
+        signer_map = fetch_and_verify(
             SIGNER_MAP_URL,
             SIGNER_MAP_SIG_URL,
-            SIGNING_ROOT_AUTHORITY_FINGERPRINTS,
-            {}
-        )
+            SIGNING_ROOT_AUTHORITY_FINGERPRINTS
+        ) or {}
+        self.app.config['SIGNER_MAP'] = (
+            signer_map['signer_map'] if 'signer_map' in signer_map else {})
+        if ('public_keys' in signer_map
+                and type(signer_map['public_keys']) == list):
+            for key in signer_map['public_keys']:
+                gpg.import_keys(key)
 
         # Fetch the hosted config
         if 'CONFIG_URL' in os.environ:
-            fetched_config = self.fetch_and_verify(
+            fetched_config = fetch_and_verify(
                 os.environ.get('CONFIG_URL'),
                 os.environ.get('CONFIG_SIG_URL'),
-                return_on_error={}
-            )
+                self.app.config['SIGNER_MAP']
+            ) or {}
             self.app.config.update(fetched_config)
 
         # Fetch secrets
@@ -416,22 +640,50 @@ class PyOIDCOP(object):
         except:
             self.app.logger.error("Unable to load credentials with credstash")
 
+        # Add client secrets to config client DB
+        client_secret_key_prefix = 'second-opinion:client_secret:'
+        for key in [x for x in self.app.config['credentials'] if
+                    x.startswith(client_secret_key_prefix)]:
+            client_id = key[len(client_secret_key_prefix):]
+            if client_id in self.app.config['OP_CLIENT_DB']:
+                self.app.config['OP_CLIENT_DB'][client_id]['client_secret'] \
+                    = self.app.config['credentials'][key]
+
         # Override the default SECRET_KEY
         self.app.config['SECRET_KEY'] = self.app.config['credentials'][
             'second-opinion:secret-key']
 
-        # Fetch authorization data
+        # Fetch authorization data for all RPs
+        # TODO : Consider how durable the cached versions of these files are
+        #  and consider the problem if they're not durable of second opinion
+        #  having to go out and fetch a bunch of different files (every
+        # clients authorization data) each time it's called. If we know the
+        # client_id on every call to second opinion where this config is
+        # needed (which I'm not sure we do), we could only fetch the data
+        # for that specific client into the config for that call.
         for client_id, authorization_urls in self.app.config.get(
                 'OP_AUTHORIZATION_URLS', {}).iteritems():
-            authorization_data = self.fetch_and_verify(
+            app.logger.debug("authorization_urls is %s : %s" %
+                             (client_id, authorization_urls))
+            client_signer_map = fetch_and_verify(
+                authorization_urls['signer_map_url'],
+                authorization_urls['signer_map_sig_url'],
+                self.app.config['SIGNER_MAP']
+            ) or {}
+
+            if 'public_keys' in client_signer_map and type(
+                    client_signer_map['public_keys']) == list:
+                for key in client_signer_map['public_keys']:
+                    gpg.import_keys(key)
+
+            authorization_data = fetch_and_verify(
                 authorization_urls['authorization_data_url'],
                 authorization_urls['authorization_data_sig_url'],
-                return_on_error={}
-            )
+                client_signer_map['signer_map']
+            ) or {}
 
             self.app.config['OP_AUTHORIZATION_DATA'][
                 client_id] = authorization_data
-            self.app.config['OP_USER_INFO'][client_id] =
 
     def teardown(self, exception):
         pass  # teardown actions
@@ -444,17 +696,28 @@ class PyOIDCOP(object):
         with the client_id of the current request
         :return: An oic provider object
         """
+        app.logger.debug("app.py PyOIDCOP.get_provider userinfo = %s" %
+                         userinfo)
+
+        duo_auth_instance = DuoAuthnMethod(
+            None, self.app)  # TODO : Why are we passing None as `srv`?
+        # This is a chicken egg problem
+        self.authn_broker.add("duo", duo_auth_instance)
+
         provider = Provider(
             name=self.app.config['OP_ISSUER'],
-            sdb=SessionDB(self.app.config['OP_ISSUER']),
+            sdb=create_session_db(
+                self.app.config['OP_ISSUER'],
+                self.app.config['SESSION_KEY'],
+                password=self.app.config['DEFAULT_TOKEN_SECRET_KEY'],
+                db=self.sdb),
             cdb=self.app.config['OP_CLIENT_DB'],
             authn_broker=self.authn_broker,
             userinfo=UserInfoWithGroups(userinfo),
             authz=AuthzHandling(),
             client_authn=verify_client,
-            symkey=None)
+            symkey=self.app.config['SYMKEY'])
         provider.baseurl = self.app.config['OP_ISSUER']
-        provider.symkey = rndstr(16)
         provider.keyjar.import_jwks(
             json.loads(
                 self.app.config['credentials']['second-opinion:opkeys']),
@@ -464,101 +727,6 @@ class PyOIDCOP(object):
             self.app.config['OP_JWKS_ROUTE']
         )
         return provider
-
-    def get_url_or_s3_object(self, url):
-        """Fetch the payload of a url from either the web or s3
-
-        :param str url:
-        :return: tuple of (success, payload)
-        """
-        if url.startswith('s3://'):
-            client = boto3.client('s3')
-            bucket_name = url[5:].split('/')[0]
-            key_name = '/'.join(url[5:].split('/')[1:])
-            try:
-                response = client.get_object(
-                    Bucket=bucket_name,
-                    Key=key_name
-                )
-            except Exception as e:
-                self.app.logger.error(
-                    "Unable to fetch %s : %s" % (url, e))
-                return False, ''
-            else:
-                return True, response['Body'].read()
-        else:
-            response = requests.get(url)
-            if not response.ok:
-                self.app.logger.error(
-                    "Unable to fetch %s : %s" % (url, response.reason))
-            return response.ok, response.content
-
-    @memory.cache
-    def fetch_and_verify(
-            self, page_url, signature_url,
-            authorized_signers=None, return_on_error=False):
-        """Fetch content from page_url and a detached signature from
-        signature_url, gpg verify that the detached signature is a valid for
-        the page and that the signer is in the authorized_signers list of
-        fingerprints. Return the page or False.
-
-        :param str page_url: URL of the page to fetch
-        :param str signature_url: URL of the detached signature for page_url
-        :param list authorized_signers: List of GPG fingerprints that are
-        authorized to sign the page or None to indicate that the
-        authorized signers should be obtained from the signer map,
-        self.app.config['SIGNER_MAP']
-        :param return_on_error: value to return on error
-        :return: payload for page_url or the content of return_on_error if
-        there is a problem with fetching or verification
-        """
-        page_success, page = self.get_url_or_s3_object(page_url)
-        signature_success, signature = self.get_url_or_s3_object(signature_url)
-        if not (page_success and signature_success):
-            return return_on_error
-        if authorized_signers is None:
-            matching_authorized_signer_lists = [
-                self.app.config['SIGNER_MAP'][url_prefix] for url_prefix
-                in self.app.config['SIGNER_MAP']
-                if page_url.startswith(url_prefix)]
-            if len(matching_authorized_signer_lists) == 0:
-                raise Exception(
-                    "No matching allowed signers for %s found in signer map" %
-                    page_url)
-            elif len(matching_authorized_signer_lists) > 0:
-                raise Exception(
-                    "Multiple matching allowed signer lists found for %s : "
-                    "%s" % (page_url, matching_authorized_signer_lists))
-            [authorized_signers] = matching_authorized_signer_lists
-
-        signature_filename = os.path.join(
-            AWS_LAMBDA_TMP_DIR,
-            hashlib.sha256(page).hexdigest()
-        )
-        with open(signature_filename) as signature_file:
-            signature_file.write(signature)
-        verification_result = gpg.verify_file(
-            file=StringIO.StringIO(page),
-            sig_file=signature_file
-        )
-        if not verification_result.valid:
-            self.app.logger.error(
-                "Unable to verify %s with detached signature %s : %s" % (
-                    page_url, signature_url, verification_result.status
-                ))
-            return return_on_error
-        if verification_result.fingerprint not in authorized_signers:
-            self.app.logger.error(
-                "Valid signature by %s of %s is not an authorized signer" % (
-                    verification_result.fingerprint, page_url
-                ))
-            return return_on_error
-        try:
-            result = json.loads(page)
-        except ValueError:
-            return return_on_error
-        else:
-            return result
 
     def get_userinfo(self, client_id=None):
         """Produce an OpenID Connect userinfo data structure for a given
@@ -628,6 +796,10 @@ class PyOIDCOP(object):
         groups = authorization_data.get('groups', {})
         return [x for x in groups if user in groups[x]]
 
+    def call_view_func(self, view_func):
+        self.provider = self.get_provider(
+            self.get_userinfo(request.args.get('client_id', None)))
+        return view_func()
 
 app = Flask(__name__)
 op = PyOIDCOP(app)

--- a/second_opinion/requirements.txt
+++ b/second_opinion/requirements.txt
@@ -4,21 +4,31 @@ credstash
 boto3
 flask
 joblib
+
+# Note we're using gnupg not python-gnupg
+#  https://github.com/isislovecruft/python-gnupg
+#  https://pythonhosted.org/gnupg/
+#  https://pypi.python.org/pypi/gnupg
+# gnupg was forked from python-gnupg@0.3.2 though python-gnupg has continued to be developed
+# https://pythonhosted.org/gnupg/gnupg.html#about-this-fork
 gnupg
 
-# Pulling from master to get the fix to this bug ( https://github.com/OpenIDC/pyoidc/pull/317 ) which is not present in v0.10.0 in pip
-git+https://github.com/OpenIDC/pyoidc.git
+# We have to pull from before https://github.com/OpenIDC/pyoidc/commit/b9279ae488500fb669e9a46324adee21040692f5
+# As this changes the aes.py tools and I'm getting an `iv` mismatch between when the cookies is encrypted and decrypted
+#
+# And we have to pull from after https://github.com/OpenIDC/pyoidc/commit/b0888c5acb7b05ff6eb31bc2ba91154745b97fd4
+# In order to get this bufix https://github.com/OpenIDC/pyoidc/pull/317
+#git+https://github.com/OpenIDC/pyoidc.git@300adc8cdf1670f6c41dd28394958162ab5a213a
+git+https://github.com/OpenIDC/pyoidc.git@f2209472b44f5a812725b98c3835e0b22665010d
+# oic == 0.11.0.0
 
-# The cryptography lambda package doesn't work https://github.com/Miserlou/lambda-packages/issues/41#issuecomment-304079770
-# So to workaround while we wait for this PR to be merged ( https://github.com/Miserlou/lambda-packages/pull/40 )
+# The cryptography lambda package doesn't work before 0.15.1
+# https://github.com/Miserlou/lambda-packages/issues/41#issuecomment-304079770
 # This must precede the installation of zappa in requirements.txt
-git+https://github.com/gene1wood/lambda-packages.git@update-cryptography-to-1.8.1
+lambda-packages >= 0.15.1
 
-# To workaround https://github.com/Miserlou/Zappa/issues/818 we need at least commit 0052d72bca7db298e28a2db46bfb3c3f09391a6b
-# But we can't go back that far as then it breaks the new python 3 zappa stuff so we'll try master?
-# And because Zappa requirements.txt fixes all package version numbers we need to use a working copy that requests lambda-packages 0.15.1
-/home/gene/code/github.com/gene1wood/Zappa/
-# git+https://github.com/Miserlou/Zappa.git
+# To workaround https://github.com/Miserlou/Zappa/issues/818 we need at least 0.41.2
+Zappa >= 0.41.2
 
 # This PR hasn't yet been merged and so the custom domain name doesn't work
 # https://github.com/Miserlou/Zappa/issues/762
@@ -27,4 +37,7 @@ git+https://github.com/gene1wood/lambda-packages.git@update-cryptography-to-1.8.
 # To workaround https://github.com/boto/botocore/issues/1148
 # And we have to run against botocore 1.5.40 because Doppins PRs aren't merging
 # https://github.com/Miserlou/Zappa/pull/796
-git+https://github.com/gene1wood/botocore.git@temp-credential-cache-on-1.5.40
+
+# We'll use the stock botocore for the moment without credential caching
+# for simplicity. Let's see if it works
+#git+https://github.com/gene1wood/botocore.git@temp-credential-cache-on-1.5.40

--- a/second_opinion/second_opinion_lambda_execution_role.json
+++ b/second_opinion/second_opinion_lambda_execution_role.json
@@ -87,7 +87,31 @@
                 }
               ]
             }
-          }
+          },
+          {
+            "PolicyName":"LetsEncryptAccountKeyReader",
+            "PolicyDocument":{
+              "Version":"2012-10-17",
+              "Statement":[
+                {
+                  "Effect":"Allow",
+                  "Action":"s3:GetObject",
+                  "Resource":"arn:aws:s3:::infosec-internal-data/*"
+                },
+                {
+                  "Effect":"Allow",
+                  "Action":"s3:ListBucket",
+                  "Resource":"arn:aws:s3:::infosec-internal-data"
+                },
+                {
+                  "Effect":"Allow",
+                  "Action":"s3:ListAllMyBuckets",
+                  "Resource":"*"
+                }
+              ]
+            }
+          },
+
         ]
       }
     }

--- a/second_opinion/where-am-i-at.md
+++ b/second_opinion/where-am-i-at.md
@@ -1,0 +1,118 @@
+# Sept 7, 2017
+
+* It looks like the `userinfo` database of users is empty at the point when the 
+  `/userinfo` endpoint attempts to query it. It looks like this is because of 
+  the chicken egg problem between the `provider` and the `authnbroker item`. So 
+  I'm reworking the whole thing to only manifest a `provider` within an active 
+  flask user query so that the `client_id` is available to pass. This doesn't 
+  solve the question of how to create a `UserAuthnMethod` which depends on an 
+  `srv` value which appears to supposed to be a `provider`, when creating a 
+  `provider` requires passing an `AuthNBroker` which contains the `UserAuthnMethod`. 
+  Chicken, egg.
+
+# Sept 6,2017
+
+* I had a malformed config.json with a different client ID. I've fixed and signed that json.
+* I've updated the clientid in testrp to match. client id and client secret on testrp match config.json and credstash currently.
+* I've broken all testrp rp logins somehow.
+* As a result my testrp logins fail before reaching second opinion
+
+# August 31, 2017
+
+* Use this to workaround mfa : `/home/gene/code/github.com/gene1wood/second-opinion/second_opinion/get-sts-session.bash`
+* I've found that [this](https://github.com/OpenIDC/pyoidc/blob/f2209472b44f5a812725b98c3835e0b22665010d/src/oic/utils/aes.py#L102) test fails causing auth to fail.
+* I just began passing into the instantiation of `DuoAuthnMethod`, the value of `self.get_provider(self.get_userinfo())` for the `srv` argument (which is also new). Determine if this works.
+* My theory is that iv and symkey are supposed to be consistent across calls by the user (and previously they were random strings generated on each call)
+* If this turns out to be true, then my temporary static setting of symkey to `testestestestest` needs to instead be a value pulled from credstash.
+* Determine if there's a version between the two commits called out in `requirements.txt` that will work.
+* I think all my debug code is being applied to a detached head of pyoidc at some specific commit. Might be worth moving around in the commit history to see if that fixes things.
+
+
+
+# August 11, 2017
+
+* I login to SO get sent to duo prompt, enter code then, duo verify succeeds, cookies set set I'm redirected to /authorize and instead of checking my cookie and sending me on, I'm presented with the duo prompt again
+* I'm trying to get the app.py:authorize endpoint to show me what's going on
+* I want to know what's happening when `oic/provider.py` calls `authnres = self.do_auth`
+* which calls `oauth2/provider.py`, but if any error were to occur in `do_auth` it wouldn't get back to me because all error info is thrown away and the user is just redirected
+* gotta figure out how to add debug code to pyoidc such that when I `zappa update dev` my copy of pyoidc gets packaged and sent to AWS lambda, not the pypi pyoidc
+* oh and I found a bug [here](https://github.com/mozilla-iam/testrp.security.allizom.org/blob/master/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/openidc_second_opinion_layer.lua#L129)
+  * `res, err, url, secondary.session = oidc.authenticate(secondary.opts, nil, secondary.session_opts)` should be `res, err, url, secondary.session = oidc.authenticate(secondary.opts, nil, nil, secondary.session_opts)`
+
+
+# August 10, 2017
+
+* second-opinion is deployed in infosec-dev. You can hit it at https://second-opinion.security.allizom.org/.well-known/openid-configuration
+* deployment required newest botocore (without persistent cache). Without it `certify` domain name setup fails
+* testrp is configured to use it
+* You can test this at : https://ldap-second-opinion.testrp.security.allizom.org/
+* When I log in, I get sent to auth0, auth, then end up logged in.
+* A call is made by testrp to fetch the well-known config from second opinion
+* No call is made to auth there though
+* The debug logs on testrp openresty show an openidc lua authenticate call but I don't know what's happening under the hood
+* Up next
+* Add debug lines to `/usr/local/openresty/nginx/conf/conf.d/second_opinion/openidc_second_opinion_layer.lua` in order to better understand what's going into the second opinion authenticate call and what's getting returned
+* Watch logs during login : `tail -f /usr/local/openresty/nginx/logs/*.log`
+* Finally when this is working diff the live testrp config against what's in git to see if I fixed anything
+* Also, make sure that whatever error condition that's happening and causing the lua openidc authenticate call to not return an `err` value can't happen again since this is a failure that allows a user in without auth
+* Also it looks like maybe the testrp php tries to display `HTTP_OIDC_CLAIM_ACCESS_TOKEN` and `HTTP_OIDC_CLAIM_ID_TOKEN` header values on the page but they're not present, not sure why this is. Maybe because [of what I output?](https://github.com/mozilla-iam/testrp.security.allizom.org/blob/master/webserver_configurations/OpenID_Connect/Nginx/conf.d/second_opinion/openidc_second_opinion_layer.lua#L170-L177)
+
+
+# July 25, 2017
+
+DONE Resign signermap.json and upload new file and sig
+DONE Redeploy with zappa to infosec-dev and figure out why gpg verification isn't working.
+DONE I've just added public keys to signermap and i should see if that works
+DONE Also, I thought the signer map showed who could sign lists of fingerprints in something. I feel like I've missed a level. If I add ulfr as a permitted signer for a given s3 directory, shouldn't he then be able to authorize an arbitrary set of signers?
+
+# June 2, 2017
+
+
+
+* Delete `second-opinion:client_secret` from infosec-dev credstash
+* Generate a new clientid and secret with `add_client.py` and inject it into the credstash of the appropriate AWS account
+* Update testrp `centos@testrp.security.allizom.org:/usr/local/openresty/nginx/conf/conf.d/second_opinion/second_opinion_options.lua` with the new cliend-id and secret and URL to the right second opinion (from the right AWS account)
+* Maybe provision testrp to talk to both dev secondopinion and prod secondopinion (grey button and red button)
+* Currently `add_client.py` doesn't do any of the gpg signing of config json containing client DB. Maybe add this or just document the process of copy pasting the output from add_client into the `config.json` and signing and uploading
+* Add to `userinfo` some "comment" or "note" field that explains where the source of the group information is (the authorization json url)
+* Confirm that the `userinfo` data structure we're sending complies to [the spec](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
+* Then maybe unit tests?
+
+# DONE
+
+I've just created `add_client.py` but I'm realizing I can't use the `remove_env`
+zappa thing to store a structured object.
+
+So I need to access it in a signed object just like the group membership data
+
+So I should skip straight to writing the code to
+* set a URL in the remove_env config that points to a json file client DB
+* set a URL in the remove_env config that points to a detached signature of that client DB json file
+* check for the presence of cached versions of those files in s3, maybe checking for their date or just setting an expiration on the s3 objects so they self delete
+* consider etag stuff so that you don't have to refetch the source URL over and over
+* if they're expired or missing, fetch the files from the source URLs
+  * Maybe kick this off as a background task somehow and use the cached, stale data that we have so we don't block on waiting for that network call
+* validate the detached signature based on a list of identities also passed in `remote_env`
+  * guess this is GPG and the identies are key fingerprints
+* ingest the now validated config
+
+Once I've got this update add_client.py to
+* add a client to a local client db
+    * fetch the client DB from s3
+    * generate a new client
+    * add it to the local client DB
+* sign a local client db
+* upload a local client Db and detached signature to s3
+
+Then use add_client.py to publish a signed clientDB to S3
+
+And fix the config.json files destined for https://github.com/mozilla/security-private/tree/master/infosec-internal-data to contain these URLs instead of structured data
+
+Next do a similar thing for the group membership data structure
+
+* Map out where everythings going to be hosted
+  * environments : dev and prod
+  * AWS Accounts : cloudtrail, infosec-prod, infosec-dev
+  * resources : KMS key for credstash, dynamodb, lambda function + apigateway, signed json config, signed json rp authorization data for testrp, route53 name
+* NO
+    * Consider enabling the credstash kms key for say `infosec-prod` to be used by the cloudtrail AWS account [like this](https://aws.amazon.com/blogs/security/share-custom-encryption-keys-more-securely-between-accounts-by-using-aws-key-management-service/)

--- a/second_opinion/zappa_settings.json
+++ b/second_opinion/zappa_settings.json
@@ -10,10 +10,10 @@
         // "debug": true,
         "apigateway_description": "Second Opinion",
         "domain": "second-opinion.security.allizom.org",
-        "lets_encrypt_key": "/path/to/second-opinion-letsencrypt-account.key",
+        "certificate_arn": "arn:aws:acm:us-east-1:656532927350:certificate/f2351003-d318-40cc-9c6f-a7aa062c6986",
         "environment_variables": {
             "CONFIG_URL": "s3://infosec-internal-data/second-opinion/dev/config.json",
-            "CONFIG_SIG_URL": "s3://infosec-internal-data/second-opinion/dev/config.asc",
+            "CONFIG_SIG_URL": "s3://infosec-internal-data/second-opinion/dev/config.json.sig"
         }
     },
     "prod": {
@@ -27,10 +27,10 @@
         // "debug": true,
         "apigateway_description": "Second Opinion",
         "domain": "second-opinion.security.mozilla.org",
-        "lets_encrypt_key": "/path/to/second-opinion-letsencrypt-account.key",
+        "certificate_arn": "",
         "environment_variables": {
             "CONFIG_URL": "s3://infosec-internal-data/second-opinion/prod/config.json",
-            "CONFIG_SIG_URL": "s3://infosec-internal-data/second-opinion/prod/config.asc",
+            "CONFIG_SIG_URL": "s3://infosec-internal-data/second-opinion/prod/config.json.sig"
         }
     }
 }


### PR DESCRIPTION
As I stopped working on this a few years back, here's the last state it was in locally.

There's no reason to think that this is functioning.

Add support for external signed authorization data

Add signing hierarchy with signature verification
Add caching for fetched files to opportunistically persist across Lambda executions using AWS_LAMBDA_TMP_DIR Change source of authorization data from local data to externally loaded, signed dictionaries Organize config loading process into an overlaying of DEFAULTS with environment variables with CONFIG_URL settings with credstash secrets

Remove pyoidc log verbosity setting of debug
Remove hard coded list of OIDC query arguments to store in the user session and pass back through after Duo authentication Add docstrings
Make Duo verification route configurable with OP_DUO_VERIFY_ROUTE setting Add add_client.py tool to provision new RPs by prompting for RP information and storing the resulting secrets with credstash Add generate_new_op_keys.py tool

